### PR TITLE
Add option to set the paginator's base bath

### DIFF
--- a/src/TableComponent.php
+++ b/src/TableComponent.php
@@ -24,6 +24,7 @@ class TableComponent extends Component
     public $sort_attribute = 'id';
     public $sort_direction = 'desc';
     public $per_page;
+    public $base_path;
 
     public function mount()
     {
@@ -46,7 +47,7 @@ class TableComponent extends Component
     {
         return view('laravel-livewire-tables::table', [
             'columns' => $this->columns(),
-            'rows' => $this->rows()->paginate($this->per_page),
+            'rows' => $this->rows()->paginate($this->per_page)->withPath($this->base_path),
         ]);
     }
 


### PR DESCRIPTION
Without this, if you change - for example - the per page (via `wire:model`) the path ends up being `livewire/message/{table-name}` and you are unable to paginate without refreshing the page first (and then you lose your per page setting).

[Laravel defaults to the current request's url](https://github.com/laravel/framework/blob/8a029557127036f0bcd82a473c2ee61e7b404d46/src/Illuminate/Pagination/PaginationServiceProvider.php#L37), so that's why it gets changed to `livewire/message`.