### PR TITLE
Add custom sorting callback

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -403,7 +403,7 @@ Additionally, your callback will be passed through Laravel's Container so you ma
 Example:
 
     Column::make('Paint Color')->searchable()->sortable()->sortUsing(function ($models, $sort_attribute, $sort_direction) {
-        return $models->orderByRaw('cast(?->\'$.amount\' as unsigned) ?', [$sort_attribute, $sort_direction]);
+        return $models->orderByRaw('?->\'$.color_code\' ?', [$sort_attribute, $sort_direction]);
     });
     
 This will sort the `paint_color` column using the JSON value `color_code`.

--- a/readme.md
+++ b/readme.md
@@ -403,10 +403,12 @@ Additionally, your callback will be passed through Laravel's Container so you ma
 Example:
 
     Column::make('Paint Color')->searchable()->sortable()->sortUsing(function ($models, $sort_attribute, $sort_direction) {
-        return $models->orderByRaw("cast({$sort_attribute}->'$.color_code' as unsigned) {$sort_direction}");
+        return $models->orderByRaw('cast(?->\'$.amount\' as unsigned) ?', [$sort_attribute, $sort_direction]);
     });
     
 This will sort the `paint_color` column using the JSON value `color_code`.
+
+**SQL Injection warning**: Make sure if you are using any of Eloquent's `*Raw` methods, you always use the bindings feature.
 
 ### `view($view)`
 

--- a/readme.md
+++ b/readme.md
@@ -390,6 +390,24 @@ Sets the column to be searchable.
 
 Sets the column to be sortable.
 
+### `sortUsing($callback)`
+
+Allows custom logic to be used for sorting. Your supplied [`callable`](https://www.php.net/manual/en/language.types.callable.php) will receive the following parameters:
+
+* `$models`: The current Eloquent query (`\Illuminate\Database\Eloquent\Builder`). You should apply your sort logic to this query, and return it.
+* `$sort_attribute`: The name of the column currently being sorted. If you used a nested relationship for sorting, it will be properly transformed to `relationship_table.column_name` format so the query will be scoped correctly.
+* `$sort_direction`: The direction sort direction requested, either `asc`, or `desc`.
+
+Additionally, your callback will be passed through Laravel's Container so you may inject any dependencies you need in your callback. Make sure your dependencies are listed before the parameters above.
+
+Example:
+
+    Column::make('Paint Color')->searchable()->sortable()->sortUsing(function ($models, $sort_attribute, $sort_direction) {
+        return $models->orderByRaw("cast({$sort_attribute}->'$.color_code' as unsigned) {$sort_direction}");
+    });
+    
+This will sort the `paint_color` column using the JSON value `color_code`.
+
 ### `view($view)`
 
 Sets a custom view to use for the column.

--- a/src/Column.php
+++ b/src/Column.php
@@ -43,10 +43,15 @@ class Column
         return $this;
     }
 
-    public function sortable(callable $callback = null)
+    public function sortable()
+    {
+        $this->sortable = true;
+        return $this;
+    }
+
+    public function sortUsing(callable $callback)
     {
         $this->sortCallback = $callback;
-        $this->sortable = true;
         return $this;
     }
 

--- a/src/Column.php
+++ b/src/Column.php
@@ -4,12 +4,21 @@ namespace Kdion4891\LaravelLivewireTables;
 
 use Illuminate\Support\Str;
 
+/**
+ * @property string $heading
+ * @property string $attribute
+ * @property boolean $searchable
+ * @property boolean $sortable
+ * @property callable $sortCallback
+ * @property string $view
+ */
 class Column
 {
     protected $heading;
     protected $attribute;
     protected $searchable = false;
     protected $sortable = false;
+    protected $sortCallback;
     protected $view;
 
     public function __construct($heading, $attribute)
@@ -34,8 +43,9 @@ class Column
         return $this;
     }
 
-    public function sortable()
+    public function sortable(callable $callback = null)
     {
+        $this->sortCallback = $callback;
         $this->sortable = true;
         return $this;
     }

--- a/src/TableComponent.php
+++ b/src/TableComponent.php
@@ -121,7 +121,7 @@ class TableComponent extends Component
         }
 
         if (($column = $this->getColumnByAttribute($this->sort_attribute)) !== null && is_callable($column->sortCallback)) {
-            return call_user_func($column->sortCallback, $models, $sort_attribute, $this->sort_direction);
+            return app()->call($column->sortCallback, ['models' => $models, 'sort_attribute' => $sort_attribute, 'sort_direction' => $this->sort_direction]);
         }
 
         return $models->orderBy($sort_attribute, $this->sort_direction);

--- a/src/TableComponent.php
+++ b/src/TableComponent.php
@@ -56,6 +56,9 @@ class TableComponent extends Component
         return \App\User::query();
     }
 
+    /**
+     * @return \Kdion4891\LaravelLivewireTables\Column[]
+     */
     public function columns()
     {
         return [
@@ -117,6 +120,10 @@ class TableComponent extends Component
             $sort_attribute = $this->sort_attribute;
         }
 
+        if (($column = $this->getColumnByAttribute($this->sort_attribute)) !== null && is_callable($column->sortCallback)) {
+            return call_user_func($column->sortCallback, $models, $sort_attribute, $this->sort_direction);
+        }
+
         return $models->orderBy($sort_attribute, $this->sort_direction);
     }
 
@@ -151,5 +158,19 @@ class TableComponent extends Component
         }
 
         $this->sort_attribute = $attribute;
+    }
+
+    /**
+     * @return null|\Kdion4891\LaravelLivewireTables\Column
+     */
+    protected function getColumnByAttribute($attribute)
+    {
+        foreach ($this->columns() as $col) {
+            if ($col->attribute === $attribute) {
+                return $col;
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
Closes #5

Allows the developer to hijack the sorting so they can sort using a JSON property within a column, or some other obscure business requirement for sorting. (I'm looking at you, Mr. Analytics...)

The readme is updated with an example. :)