### PR TITLE
Add support for Livewire 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "laravel/framework": "6.*",
         "laravel/ui": "^1.1",
-        "livewire/livewire": "^0.7.0"
+        "livewire/livewire": "^0.7.0|^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
No breaking changes (as far as I could tell), so this is still fully compatible with v0.7