### PR TITLE
implementing like_operator to allow postgresql ILIKE in query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+/node_modules
+/public/hot
+/public/storage
+/storage/*.key
+/vendor
+.env
+.env.backup
+.phpunit.result.cache
+Homestead.json
+Homestead.yaml
+npm-debug.log
+yarn-error.log

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "workbench.colorCustomizations": {
-        "activityBar.background": "#250794",
-        "titleBar.activeBackground": "#330ACF",
-        "titleBar.activeForeground": "#FCFCFF"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#250794",
+        "titleBar.activeBackground": "#330ACF",
+        "titleBar.activeForeground": "#FCFCFF"
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,8 @@ After making a component, you may want to edit the `query` and `column` methods:
         }
     }
     
+In the query method is possible to change the like operator to allow the use of "ilike" operator in postgresql. 
+    
 You don't have to use the `render()` method in your table component or worry about a component view, because the package handles that automatically.
 
 # Using Table Components

--- a/src/TableComponent.php
+++ b/src/TableComponent.php
@@ -25,7 +25,7 @@ class TableComponent extends Component
     public $sort_attribute = 'id';
     public $sort_direction = 'desc';
     public $per_page;
-
+    public $like_operator= 'like'; 
     public function mount()
     {
         $this->setTableProperties();
@@ -97,7 +97,7 @@ class TableComponent extends Component
                             $relationship = $this->relationship($column->attribute);
 
                             $query->orWhereHas($relationship->name, function (Builder $query) use ($relationship) {
-                                $query->where($relationship->attribute, 'like', '%' . $this->search . '%');
+                                $query->where($relationship->attribute, $this->like_operator, '%' . $this->search . '%');
                             });
                         }
                         else if (Str::endsWith($column->attribute, '_count')) {
@@ -105,7 +105,7 @@ class TableComponent extends Component
                             // If you read this and have a good solution, feel free to submit a PR :P
                         }
                         else {
-                            $query->orWhere($query->getModel()->getTable() . '.' . $column->attribute, 'like', '%' . $this->search . '%');
+                            $query->orWhere($query->getModel()->getTable() . '.' . $column->attribute, $this->like_operator, '%' . $this->search . '%');
                         }
                     }
                 }

--- a/src/TableComponent.php
+++ b/src/TableComponent.php
@@ -26,6 +26,7 @@ class TableComponent extends Component
     public $sort_direction = 'desc';
     public $per_page;
     public $like_operator= 'like'; 
+    
     public function mount()
     {
         $this->setTableProperties();


### PR DESCRIPTION
With this is possible to set the like operator 
Specially in postgresql is important to allow the case-insensitive search
use example: 

public function query()
    {
        $this->like_operator = 'ilike';     
        return Facultad::with('institucion');
    }

